### PR TITLE
Wordlist manager uses file's path

### DIFF
--- a/lib/features/hashing/presentation/hash_cracker_screen.dart
+++ b/lib/features/hashing/presentation/hash_cracker_screen.dart
@@ -197,7 +197,8 @@ class HashCrackerScreen extends HookConsumerWidget {
 
           if(algorithmType == HashAlgorithmType.unknown) {
             algorithmType = notifier.identifyHash(hash);
-
+            selectedAlgorithm.value = algorithmType;
+            
             if(algorithmType == HashAlgorithmType.unknown){
 
               if(!context.mounted) return;

--- a/lib/features/wordlists/presentation/word_list_choice_screen.dart
+++ b/lib/features/wordlists/presentation/word_list_choice_screen.dart
@@ -39,10 +39,10 @@ class WordListChoiceScreen extends HookConsumerWidget {
                   padding: const EdgeInsets.all(10),
                   child: TextButton(
                     onPressed: () {
-                      pickedFilePath.value = wordListsState[index];
+                      pickedFilePath.value = wordListsState[index].split('/').last;
                       Navigator.of(context).pop();
                     },
-                    child: Text(truncateFileName(wordListsState[index], 25)),
+                    child: Text(truncateFileName(wordListsState[index].split('/').last, 25)),
                   ),
                 ),
               ),

--- a/lib/features/wordlists/presentation/word_list_choice_screen.dart
+++ b/lib/features/wordlists/presentation/word_list_choice_screen.dart
@@ -39,7 +39,7 @@ class WordListChoiceScreen extends HookConsumerWidget {
                   padding: const EdgeInsets.all(10),
                   child: TextButton(
                     onPressed: () {
-                      pickedFilePath.value = wordListsState[index].split('/').last;
+                      pickedFilePath.value = wordListsState[index];
                       Navigator.of(context).pop();
                     },
                     child: Text(truncateFileName(wordListsState[index].split('/').last, 25)),

--- a/lib/features/wordlists/presentation/word_lists_screen.dart
+++ b/lib/features/wordlists/presentation/word_lists_screen.dart
@@ -103,17 +103,17 @@ class WordListsScreen extends HookConsumerWidget {
                 child: ListView.builder(
                   itemCount: wordListsScreenState.wordLists.length,
                   itemBuilder: (context, index) => WordListItem(
-                    wordListName: wordListsScreenState.wordLists[index], 
+                    wordListName: wordListsScreenState.wordLists[index].split('/').last, 
                     onEditPressed: () => navigateTo(
                       context, 
                       routes.editWordList,
-                      arguments: wordListsScreenState.wordLists[index],
+                      arguments: wordListsScreenState.wordLists[index].split('/').last,
                     ).whenComplete(
                       () => notifier.loadWordListsName()
                     ),
                     onDeletePressed: () {
-                      final name = wordListsScreenState.wordLists[index];
-                      notifier.deleteWordList(name);
+                      final path = wordListsScreenState.wordLists[index];
+                      notifier.deleteWordList(path);
                     }
                   ),
                 ),

--- a/lib/shared/data/word_list_manager.dart
+++ b/lib/shared/data/word_list_manager.dart
@@ -19,8 +19,8 @@ class WordListManager {
     await file.create();
   }
 
-  Future<void> deleteWordList(String name) async {
-    final file = await _getLocalFile(name);
+  Future<void> deleteWordList(path) async {
+    final file = File(path);
     await file.delete();
   }
 
@@ -29,7 +29,7 @@ class WordListManager {
 
     return await directory.list(recursive: false)
       .where((entity) => entity is File)
-      .map((entity) => entity.path.split('/').last)
+      .map((entity) => entity.path)
       .toList();
   }
 
@@ -42,14 +42,8 @@ class WordListManager {
     );
   }
 
-  Future<List<String>> loadWordList(String fileName) async {
-
-    var file = File(fileName);
-
-    if(file.parent.path == '.'){
-      file = await _getLocalFile(fileName);
-    }
-    
+  Future<List<String>> loadWordList(String filePath) async {
+    var file = File(filePath);    
     return await file.readAsLines();
   }
 


### PR DESCRIPTION
The WordList manager returns a list of paths instead of file names, which results in an easier loadWordList function but requires some modifications elsewhere.