### PR TITLE
Add wordlist download from the web

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ FlutCrack is a Flutter application designed to crack hashes by comparing them ag
   - SHA-512/224
   - SHA-512/256
 - User-friendly interface with text input and dropdown selection for hash algorithms
+- Dynamic wordlists support ( from web, device memory or in-app created )
 - Words hasher
 
 ## 👩‍💻 Installation
@@ -70,7 +71,7 @@ You may need to allow installations from unknown sources. This can be done by go
 
 1. Open the FlutCrack application on your device or emulator.
 2. Before cracking your hash, go to the wordlists section, create and add words to your wordlist. This step is required only on the first run, as the previous wordlist will be saved for future use.
-3. Go back to the home screen, pick the wordlist you want to use from those you created of from your device memory.
+3. Go back to the home screen, pick the wordlist you want to use from those you created, from your device memory or from the web.
 4. Enter the hash you want to crack in the text field.
 5. Select the hash algorithm from the dropdown menu (if you know it).
 6. Press the action button to start the cracking process.
@@ -84,6 +85,7 @@ You may need to allow installations from unknown sources. This can be done by go
 - [x] Cleaner code
 - [x] New UI
 - [x] Multiple wordlists support
+- [x] Web Wordlists installation
 
 ## 🧩 Contributing
 We welcome contributions! Please follow these steps:

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
         android:requestLegacyExternalStorage="true"

--- a/lib/app_routes.dart
+++ b/lib/app_routes.dart
@@ -4,4 +4,5 @@ const String hasher = '/hasher';
 const String editWordList = '/edit';
 const String home = '/';
 const String manageWordLists = '/manage-wordlists';
+const String networkWordListChoice = '/network-worlists';
 const String wordListChoice = '/word-list-choice';

--- a/lib/core/utils/http_utils.dart
+++ b/lib/core/utils/http_utils.dart
@@ -3,6 +3,9 @@ import 'package:http/http.dart' as http;
 Future<String?> getURLContent(url) async {
   try {
     var response = await http.get(Uri.parse(url));
+    if (response.statusCode != 200) {
+      return null;
+    }
     return response.body;
   } catch (e) {
     return null;

--- a/lib/core/utils/http_utils.dart
+++ b/lib/core/utils/http_utils.dart
@@ -1,0 +1,10 @@
+import 'package:http/http.dart' as http;
+
+Future<String?> getURLContent(url) async {
+  try {
+    var response = await http.get(Uri.parse(url));
+    return response.body;
+  } catch (e) {
+    return null;
+  }
+}

--- a/lib/features/about/presentation/aboutus_screen.dart
+++ b/lib/features/about/presentation/aboutus_screen.dart
@@ -23,7 +23,7 @@ class AboutUsScreen extends StatelessWidget {
                 Icons.thumb_up, 
                 color: colorScheme.primary
               ),
-              title: const Text("FlutCrack 2.0"),
+              title: const Text("FlutCrack 2.1"),
             ),
             ListTile(
               leading: Icon(Icons.balance, color: colorScheme.primary),

--- a/lib/features/hashing/presentation/hash_cracker_screen.dart
+++ b/lib/features/hashing/presentation/hash_cracker_screen.dart
@@ -176,6 +176,11 @@ class HashCrackerScreen extends HookConsumerWidget {
                       context, 
                       routes.wordListChoice, 
                       arguments: pickedFilePath
+                    ),
+                    onNetworkPick: () async => await navigateTo(
+                      context,
+                      routes.networkWordListChoice,
+                      arguments: pickedFilePath
                     )
                   );
                 }
@@ -190,7 +195,7 @@ class HashCrackerScreen extends HookConsumerWidget {
         ),
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () async { 
+        onPressed: () async {
           
           final hash = hashTextController.text.trim();
           HashAlgorithmType algorithmType = selectedAlgorithm.value;

--- a/lib/features/hashing/presentation/widgets/dialog_widget.dart
+++ b/lib/features/hashing/presentation/widgets/dialog_widget.dart
@@ -4,11 +4,13 @@ class DialogWidget extends StatelessWidget {
   
   final void Function() onFilePick;
   final void Function() onWordListPick;
+  final void Function() onNetworkPick;
   
   const DialogWidget({
     super.key,
     required this.onFilePick,
-    required this.onWordListPick  
+    required this.onWordListPick,
+    required this.onNetworkPick,
   });
 
   @override
@@ -37,6 +39,15 @@ class DialogWidget extends StatelessWidget {
               icon: const Icon(Icons.file_open),
               label: const Text('Use a in-app created wordlist'),
             ),
+            const SizedBox(height: 15),
+            ElevatedButton.icon(
+              onPressed: () {
+                Navigator.of(context).pop();
+                onNetworkPick();
+              },
+              icon: const Icon(Icons.download),
+              label: const Text('Use an online wordlist'),
+            )
           ],
         ),
       )

--- a/lib/features/wordlists/data/repositories/word_list_repository_impl.dart
+++ b/lib/features/wordlists/data/repositories/word_list_repository_impl.dart
@@ -37,16 +37,15 @@ class WordListRepositoryImpl implements WordListRepository {
     final String wordListName = link.split('/').last;
     final String? response = await getURLContent(link);
     
-    if (response != null ) {
-      List<String> words = response.split('\n');
-
-      return 
-        await createEmptyWordList(wordListName) & 
-        await appendWordsTo(wordListName, words);
-
+    if (response == null) {
+      return false;
     }
 
-    return false;
+    List<String> words = response.split('\n');
+
+    return 
+      await createEmptyWordList(wordListName) &&
+      await appendWordsTo(wordListName, words);
   }
 
   @override

--- a/lib/features/wordlists/data/repositories/word_list_repository_impl.dart
+++ b/lib/features/wordlists/data/repositories/word_list_repository_impl.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flut_crack/core/utils/http_utils.dart';
 import 'package:flut_crack/shared/data/word_list_manager.dart';
 import 'package:flut_crack/features/wordlists/domain/repositories/word_list_repository.dart';
 
@@ -29,6 +30,23 @@ class WordListRepositoryImpl implements WordListRepository {
   @override
   Future<List<String>> getAllWordListsNames() async {
     return await _wordListManager.getWordListsNames();
+  }
+
+  @override
+  Future<bool> downloadWordList(String link) async {
+    final String wordListName = link.split('/').last;
+    final String? response = await getURLContent(link);
+    
+    if (response != null ) {
+      List<String> words = response.split('\n');
+
+      return 
+        await createEmptyWordList(wordListName) & 
+        await appendWordsTo(wordListName, words);
+
+    }
+
+    return false;
   }
 
   @override

--- a/lib/features/wordlists/domain/repositories/word_list_repository.dart
+++ b/lib/features/wordlists/domain/repositories/word_list_repository.dart
@@ -7,6 +7,7 @@ abstract class WordListRepository {
 
   Future<bool> createEmptyWordList(String name);
   Future<bool> deleteWordList(String name);
+  Future<bool> downloadWordList(String link);
   Future<bool> renameWordList(String currentName, String newName);
   Future<bool> appendWordsTo(String wordListName, List<String> words);
 }

--- a/lib/features/wordlists/domain/usecases/download_word_list_use_case.dart
+++ b/lib/features/wordlists/domain/usecases/download_word_list_use_case.dart
@@ -1,0 +1,21 @@
+import 'package:flut_crack/core/use_case.dart';
+import 'package:flut_crack/features/wordlists/domain/repositories/word_list_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class DownloadWordListUseCase extends
+  UseCase<String, Future<bool>> {
+
+  final WordListRepository _repository;
+
+  DownloadWordListUseCase(this._repository);
+
+  @override
+  Future<bool> call(String params) async {
+    return await _repository.downloadWordList(params);
+  }
+}
+
+final downloadWordListUseCaseProvider = Provider((ref){
+  final repo = ref.read(wordListRepositoryProvider);
+  return DownloadWordListUseCase(repo);
+});

--- a/lib/features/wordlists/presentation/network_word_list_choice_screen.dart
+++ b/lib/features/wordlists/presentation/network_word_list_choice_screen.dart
@@ -1,0 +1,54 @@
+import 'package:flut_crack/core/utils/snackbar_utils.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:flutter/material.dart';
+
+import 'package:flut_crack/core/utils/navigation_utils.dart';
+import 'package:flut_crack/features/wordlists/presentation/state/download_word_list_state_notifier.dart';
+
+class NetworkWordListChoiceScreen extends HookConsumerWidget {
+  const NetworkWordListChoiceScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final pickedFilePath = extractArguments<ValueNotifier<String?>>(context);  
+    final wordListLinkController = useTextEditingController();
+
+    final notifier = ref.read(downloadWordListScreenNotifierProvider.notifier);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Use an online wordlist"),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextFormField(
+              controller: wordListLinkController,
+              decoration: const InputDecoration(
+                prefixIcon: Icon(Icons.download),
+                hintText: "Link of the wordlist",
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
+              onPressed: () {
+                if (wordListLinkController.text.isNotEmpty) {
+                  notifier.downloadWordList(wordListLinkController.text);
+                  pickedFilePath.value = wordListLinkController.text.split('/').last;
+                  Navigator.of(context).pop();
+                } else {
+                  showErrorSnackBar(context, "Use a valid url");
+                }
+              },
+              label: const Text("Send request"),
+              icon: const Icon(Icons.arrow_right_alt)
+            ),
+          ]
+        )
+      )
+    );
+  }
+}

--- a/lib/features/wordlists/presentation/state/download_word_list_state_notifier.dart
+++ b/lib/features/wordlists/presentation/state/download_word_list_state_notifier.dart
@@ -1,10 +1,36 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:flutter/foundation.dart';
+
 import 'package:flut_crack/features/wordlists/domain/usecases/download_word_list_use_case.dart';
 
-enum NetworkScreenState {
+enum NetworkConcreteState {
   idle,
+  downloading,
   downloadSuccess,
   downloadFailed
+}
+
+@immutable
+class NetworkScreenState { 
+
+  final NetworkConcreteState state;
+
+  const NetworkScreenState({
+    required this.state
+  });
+
+  const NetworkScreenState.downloading()
+    : state = NetworkConcreteState.downloading;
+
+  const NetworkScreenState.idle() 
+    : state = NetworkConcreteState.idle;
+
+  const NetworkScreenState.downloadFailed() 
+    : state = NetworkConcreteState.downloadFailed;
+
+  const NetworkScreenState.downloadSuccess() 
+    : state = NetworkConcreteState.downloadSuccess;
+
 }
 
 class NetworkScreenNotifier extends StateNotifier<NetworkScreenState> {
@@ -12,15 +38,23 @@ class NetworkScreenNotifier extends StateNotifier<NetworkScreenState> {
 
   NetworkScreenNotifier({
     required this.downloadWordListUseCase
-  }) : super(NetworkScreenState.idle);
+  }) : super(const NetworkScreenState.idle());
 
   Future<void> downloadWordList(String link) async {
+  try {
+    state = const NetworkScreenState.downloading();
     final downloaded = await downloadWordListUseCase(link);
 
-    downloaded == true
-      ? NetworkScreenState.downloadSuccess
-      : NetworkScreenState.downloadFailed;
+    if (downloaded) {
+      state = const NetworkScreenState.downloadSuccess();
+    } else {
+      state = const NetworkScreenState.downloadFailed();
+    }
+  } catch (e) {
+    state = const NetworkScreenState.downloadFailed();
   }
+}
+
 }
 
 final downloadWordListScreenNotifierProvider = 

--- a/lib/features/wordlists/presentation/state/download_word_list_state_notifier.dart
+++ b/lib/features/wordlists/presentation/state/download_word_list_state_notifier.dart
@@ -1,0 +1,33 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:flut_crack/features/wordlists/domain/usecases/download_word_list_use_case.dart';
+
+enum NetworkScreenState {
+  idle,
+  downloadSuccess,
+  downloadFailed
+}
+
+class NetworkScreenNotifier extends StateNotifier<NetworkScreenState> {
+  final DownloadWordListUseCase downloadWordListUseCase;
+
+  NetworkScreenNotifier({
+    required this.downloadWordListUseCase
+  }) : super(NetworkScreenState.idle);
+
+  Future<void> downloadWordList(String link) async {
+    final downloaded = await downloadWordListUseCase(link);
+
+    downloaded == true
+      ? NetworkScreenState.downloadSuccess
+      : NetworkScreenState.downloadFailed;
+  }
+}
+
+final downloadWordListScreenNotifierProvider = 
+  StateNotifierProvider.autoDispose<NetworkScreenNotifier, NetworkScreenState>((ref){
+    final downloadWordListUseCase = ref.read(downloadWordListUseCaseProvider);
+
+    return NetworkScreenNotifier(
+      downloadWordListUseCase: downloadWordListUseCase
+    );
+  });

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flut_crack/features/hashing/presentation/hasher_screen.dart';
 import 'package:flut_crack/features/wordlists/presentation/word_lists_screen.dart';
 import 'package:flut_crack/features/wordlists/presentation/word_list_choice_screen.dart';
+import 'package:flut_crack/features/wordlists/presentation/network_word_list_choice_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -40,6 +41,7 @@ class FlutCrack extends StatelessWidget {
         routes.hasher: (context) => const HasherScreen(),
         routes.home: (context) => const HomeScreen(),
         routes.manageWordLists: (context) => const WordListsScreen(),
+        routes.networkWordListChoice: (context) => const NetworkWordListChoiceScreen(),
         routes.wordListChoice: (context) => const WordListChoiceScreen()
       },
     );

--- a/lib/shared/data/word_list_manager.dart
+++ b/lib/shared/data/word_list_manager.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path_provider/path_provider.dart';
 
 class WordListManager {
-
+  
   Future<String> get localPath async {
     final directory = await getApplicationDocumentsDirectory();
     return directory.path;
@@ -19,7 +19,7 @@ class WordListManager {
     await file.create();
   }
 
-  Future<void> deleteWordList(path) async {
+  Future<void> deleteWordList(String path) async {
     final file = File(path);
     await file.delete();
   }
@@ -43,8 +43,13 @@ class WordListManager {
   }
 
   Future<List<String>> loadWordList(String filePath) async {
-    var file = File(filePath);    
-    return await file.readAsLines();
+    try {
+      var file = File(filePath);    
+      return await file.readAsLines();
+    } catch(e) {
+      var file = await _getLocalFile(filePath);
+      return file.readAsLines();
+    }
   }
 
   Future<void> renameWordList(String oldName, String newName) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -433,7 +433,7 @@ packages:
     source: hosted
     version: "4.2.0"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   flutter_riverpod: ^2.5.1
   hooks_riverpod: ^2.5.1
   flutter_hooks: ^0.20.5
+  http: ^1.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Add a new option in the dialog widget to show the "download from the web" option
- Add routes for the network download screen
- Add internet permission to manifest
- Create network_word_list_choice_use_case to abstract the network function
- Create network_word_list_choice_screen to show the TextField for link input
- Create core/utils/http_utils.dart to retrieve data from the web